### PR TITLE
Mark slack_url as optional

### DIFF
--- a/lib/scan/options.rb
+++ b/lib/scan/options.rb
@@ -98,6 +98,7 @@ module Scan
         FastlaneCore::ConfigItem.new(key: :slack_url,
                                      env_name: "SLACK_URL",
                                      description: "Create an Incoming WebHook for your Slack group to post results there",
+                                     optional: true,
                                      verify_block: proc do |value|
                                        raise "Invalid URL, must start with https://" unless value.start_with? "https://"
                                      end),

--- a/lib/scan/slack_poster.rb
+++ b/lib/scan/slack_poster.rb
@@ -3,6 +3,7 @@ module Scan
     def run(results)
       return if Scan.config[:skip_slack]
       return if Scan.config[:slack_only_on_failure] && results[:failures] == 0
+      return if Scan.config[:slack_url].nil?
 
       require 'slack-notifier'
       notifier = Slack::Notifier.new(Scan.config[:slack_url])


### PR DESCRIPTION
Fixes #1 

Additionally, added an early return if `:slack_url` is empty.

The only thing that concerns me is I don't see anywhere to put a spec for this.
