### PR TITLE
Support device selection + simulator version

### DIFF
--- a/lib/scan.rb
+++ b/lib/scan.rb
@@ -20,6 +20,8 @@ module Scan
 
     attr_accessor :cache
 
+    attr_accessor :device
+
     def config=(value)
       @config = value
       DetectValues.set_additional_default_values

--- a/lib/scan/detect_values.rb
+++ b/lib/scan/detect_values.rb
@@ -26,9 +26,14 @@ module Scan
       config = Scan.config
 
       if config[:device] # make sure it actually exists
-        found = FastlaneCore::Simulator.all.find { |d| d.name == config[:device].to_s.strip }
+
+        device = config[:device].to_s.strip.tr('()', '') # Remove parenthesis
+
+        found = FastlaneCore::Simulator.all.find { |d| (d.name + " " + d.ios_version).include? device }
+        found = nil
+
         if found
-          config[:device] = found
+          Scan.device = found
           return
         else
           Helper.log.error "Couldn't find simulator '#{config[:device]}' - falling back to default simulator".red
@@ -39,8 +44,9 @@ module Scan
       found = FastlaneCore::Simulator.all.find { |d| d.name == "iPhone 5s" }
       found ||= FastlaneCore::Simulator.all.first # anything is better than nothing
 
-      config[:device] = found
-      raise "No simulators found".red unless config[:device]
+      Scan.device = found
+
+      raise "No simulators found".red unless Scan.device
     end
 
     # Is it an iOS device or a Mac?
@@ -55,7 +61,7 @@ module Scan
 
       # building up the destination now
       if Scan.project.ios?
-        Scan.config[:destination] = "platform=iOS Simulator,id=#{Scan.config[:device].udid}"
+        Scan.config[:destination] = "platform=iOS Simulator,id=#{Scan.device.udid}"
       else
         Scan.config[:destination] = "platform=OS X"
       end

--- a/lib/scan/options.rb
+++ b/lib/scan/options.rb
@@ -30,7 +30,7 @@ module Scan
         FastlaneCore::ConfigItem.new(key: :device,
                                      short_option: "-a",
                                      optional: true,
-                                     is_string: false,
+                                     is_string: true,
                                      env_name: "SCAN_DEVICE",
                                      description: "The name of the simulator type you want to run tests on"),
         FastlaneCore::ConfigItem.new(key: :scheme,


### PR DESCRIPTION
Fixes the device selection with `--device` parameter. Device parameter is now read correctly and tries to match the installed simulator.

`--device "iPhone 6"` - Will match the first available version of iPhone 6 Simulator.
`--device "iPhone 6 9.0"` - Will match the iPhone 6 **9.0** Simulator version.
`--device "iPhone 6 (9.0)"` - Will also match the iPhone 6 **9.0** Simulator version.

Fixes the error:
`ERROR [2015-10-29 10:05:52.97]: Couldn't find simulator 'true' - falling back to default simulator`

Also fixes: #18 

Please check if everything looks good.
