### PR TITLE
Fix a typo in ScanfileTemplate

### DIFF
--- a/lib/assets/ScanfileTemplate
+++ b/lib/assets/ScanfileTemplate
@@ -1,4 +1,4 @@
-# For more information about this configuation visit
+# For more information about this configuration visit
 # https://github.com/fastlane/scan#scanfile
 
 # In general, you can use the options available


### PR DESCRIPTION
Fix a small typo: "configuation" => "configuration"
