### PR TITLE
Change default test output foler

### DIFF
--- a/lib/scan/options.rb
+++ b/lib/scan/options.rb
@@ -48,7 +48,7 @@ module Scan
                                      short_option: "-o",
                                      env_name: "SCAN_OUTPUT_DIRECTORY",
                                      description: "The directory in which all reports will be stored",
-                                     default_value: "./test_output"),
+                                     default_value: "./fastlane/test_output"),
         FastlaneCore::ConfigItem.new(key: :output_style,
                                      short_option: "-b",
                                      env_name: "SCAN_OUTPUT_STYLE",


### PR DESCRIPTION
Hi,

As the [Gitignore Doc](https://github.com/fastlane/fastlane/blob/master/docs/Gitignore.md) mentioned, the test output files for `scan` should be under `fastlane/test_output`. However, it seems that `scan` now outputs the result under a folder in the working directory (which is the project folder) directly. 

Although it will not be a critical problem most of time, there is a potential risk to override things in the original folder.

I guess it could be a better choice to keep the output under `fastlane/test_output` instead of `test_output`.
