### PR TITLE
Add example of the device parameter in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Make sure, you have the latest version of the Xcode command line tools installed
 
 That's all you need to run your tests. If you want more control, here are some available parameters:
 
-    scan --workspace "Example.xcworkspace" --scheme "AppName" --clean
+    scan --workspace "Example.xcworkspace" --scheme "AppName" --device "iPhone 6 (8.1)" --clean
 
 If you need to use a different xcode install, use xcode-select or define DEVELOPER_DIR:
 


### PR DESCRIPTION
This is the minimum viable solution to the problem I ran into.

I first tried to pass `--device "platform=iOS Simulator,name=iPhone 5s,OS=9.1"` which of course wouldn't work.

Neither `--help` nor any documentation tells you how this should be formatted, I guessed the format by looking at the `default_device` code.

Proposal: Maybe a `verify_block` should be added and maybe not fail but at least warn the user if the passed value looks bogus (for example when it contains a `=`).
