### PR TITLE
Run xcodebuild with NSUnbufferedIO=YES environment variable

### DIFF
--- a/lib/scan/test_command_generator.rb
+++ b/lib/scan/test_command_generator.rb
@@ -4,7 +4,7 @@ module Scan
     class << self
       def generate
         parts = prefix
-        parts << "xcodebuild"
+        parts << "env NSUnbufferedIO=YES xcodebuild"
         parts += options
         parts += actions
         parts += suffix


### PR DESCRIPTION
When xcodebuild is piped (even through a simple `cat`) the test results output becomes buffered. This is very annoying when piped through xcpretty because the test results only appear once all the tests have run.

Setting the `NSUnbufferedIO` environment variable to `YES` when running xcodebuild solves this issue, see http://stackoverflow.com/questions/18995187/xcodebuild-corrupts-test-result-output-when-output-redirected-to-file/19190226#comment54275017_19190226
