### PR TITLE
Only add travis formatter when running on TRAVIS

### DIFF
--- a/lib/scan/test_command_generator.rb
+++ b/lib/scan/test_command_generator.rb
@@ -61,7 +61,7 @@ module Scan
         # During building we just show the output in the terminal
         # Check out the ReportCollector class for more xcpretty things
         formatter = []
-        if Helper.ci?
+        if ENV.key?["TRAVIS"]
           formatter << "-f `xcpretty-travis-formatter`"
           Helper.log.info "Automatically switched to Travis formatter".green
         end


### PR DESCRIPTION
The formatter has some weird output which you might not want in Jenkins or other CI systems that don't support the Travis way of formatting.
