### PR TITLE
Remove build from test_command_generator 

### DIFF
--- a/lib/scan/test_command_generator.rb
+++ b/lib/scan/test_command_generator.rb
@@ -46,7 +46,6 @@ module Scan
 
         actions = []
         actions << :clean if config[:clean]
-        actions << :build
         actions << :test
 
         actions


### PR DESCRIPTION
This is to remove the build command from scan. The test command builds and tests the UTs, adding a build command to this makes it redundant and increases execution times.
