### PR TITLE
Disable xcpretty colors when FASTLANE_DISABLE_COLORS is set

### DIFF
--- a/lib/scan/test_command_generator.rb
+++ b/lib/scan/test_command_generator.rb
@@ -66,6 +66,10 @@ module Scan
           Helper.log.info "Automatically switched to Travis formatter".green
         end
 
+        if ENV["FASTLANE_DISABLE_COLORS"]
+          formatter << "--no-color"
+        end
+
         if Scan.config[:output_style] == 'basic'
           formatter << "--no-utf"
         end


### PR DESCRIPTION
xcpretty continues to give colored output even when the `FASTLANE_DISABLE_COLORS` environment variable is set.
This commit disables the colors in xcpretty when the env variable is set.
