### PR TITLE
Suggestion to add the option to omit exception on failing tests

### DIFF
--- a/lib/scan/options.rb
+++ b/lib/scan/options.rb
@@ -125,7 +125,12 @@ module Scan
         FastlaneCore::ConfigItem.new(key: :slack_only_on_failure,
                                     description: "Only post on Slack if the tests fail",
                                     is_string: false,
-                                    default_value: false)
+                                    default_value: false),
+        FastlaneCore::ConfigItem.new(key: :omit_exception_on_failing_tests,
+                                    description: "Don't throw an exception if any test fails",
+                                    default_value: false,
+                                    optional: true,
+                                    is_string: false)
       ]
     end
   end

--- a/lib/scan/runner.rb
+++ b/lib/scan/runner.rb
@@ -67,6 +67,7 @@ module Scan
       ReportCollector.new.parse_raw_file(TestCommandGenerator.xcodebuild_log_path)
 
       raise "Tests failed" unless result[:failures] == 0 || Scan.config[:omit_exception_on_failing_tests]
+      result[:failures] # return number of failed tests
     end
   end
 end

--- a/lib/scan/runner.rb
+++ b/lib/scan/runner.rb
@@ -66,7 +66,7 @@ module Scan
 
       ReportCollector.new.parse_raw_file(TestCommandGenerator.xcodebuild_log_path)
 
-      raise "Tests failed" unless result[:failures] == 0
+      raise "Tests failed" unless result[:failures] == 0 || Scan.config[:omit_exception_on_failing_tests]
     end
   end
 end


### PR DESCRIPTION
Adds an option to omit the exception on failing tests.
This addition preserves the default behaviour to not break existing setups.
Additionally, the number of failing tests is provided as return value.

This change is to support the use case, where the test results should be processed in every case, e.g:

```
scan
slather
sonar
```

Here, the test result is forwarded to SonarQube, where I want failing tests to appear as well as succeeding tests.

Using the `error` block is not an alternative here, since it skips the lane's remaining actions.
This is the currently the only solution for my use case.
What do you think? :)

Thanks,
Chris
