### PR TITLE
Optimize the tests to run faster

### DIFF
--- a/lib/scan/report_collector.rb
+++ b/lib/scan/report_collector.rb
@@ -2,6 +2,13 @@ module Scan
   class ReportCollector
     SUPPORTED = %w(html junit json-compilation-database)
 
+    # Intialize with values from Scan.config matching these param names
+    def initialize(open_report, output_types, output_directory)
+      @open_report = open_report
+      @output_types = output_types
+      @output_directory = output_directory
+    end
+
     def parse_raw_file(path)
       raise "Couldn't find file at path '#{path}'".red unless File.exist?(path)
 
@@ -10,7 +17,7 @@ module Scan
         system(command)
         Helper.log.info("Successfully generated report at '#{output_path}'".green)
 
-        if Scan.config[:open_report] and output_path.end_with?(".html")
+        if @open_report and output_path.end_with?(".html")
           # Open the HTML file
           `open --hide '#{output_path}'`
         end
@@ -19,7 +26,7 @@ module Scan
 
     # Returns a hash containg the resulting path as key and the command as value
     def generate_commands(path, types: nil, output_file_name: nil)
-      types ||= Scan.config[:output_types]
+      types ||= @output_types
       types = types.split(",") if types.kind_of?(String) # might already be an array when passed via fastlane
       commands = {}
 
@@ -32,7 +39,7 @@ module Scan
         end
 
         file_name = "report.#{type}"
-        output_path = output_file_name || File.join(File.expand_path(Scan.config[:output_directory]), file_name)
+        output_path = output_file_name || File.join(File.expand_path(@output_directory), file_name)
         parts = ["cat '#{path}' | "]
         parts << "xcpretty"
         parts << "--report #{type}"

--- a/lib/scan/runner.rb
+++ b/lib/scan/runner.rb
@@ -43,9 +43,14 @@ module Scan
       # First, generate a JUnit report to get the number of tests
       require 'tempfile'
       output_file = Tempfile.new("junit_report")
-      cmd = ReportCollector.new.generate_commands(TestCommandGenerator.xcodebuild_log_path,
-                                                  types: 'junit',
-                                                  output_file_name: output_file.path).values.last
+
+      report_collector = ReportCollector.new(Scan.config[:open_report],
+                                             Scan.config[:output_types],
+                                             Scan.config[:output_directory])
+
+      cmd = report_collector.generate_commands(TestCommandGenerator.xcodebuild_log_path,
+                                               types: 'junit',
+                                               output_file_name: output_file.path).values.last
       system(cmd)
 
       result = TestResultParser.new.parse_result(output_file.read)
@@ -66,7 +71,7 @@ module Scan
       })
       puts ""
 
-      ReportCollector.new.parse_raw_file(TestCommandGenerator.xcodebuild_log_path)
+      report_collector.parse_raw_file(TestCommandGenerator.xcodebuild_log_path)
 
       UI.user_error!("Test execution failed. Exit status: #{tests_exit_status}") unless tests_exit_status == 0
       UI.user_error!("Tests failed") unless result[:failures] == 0

--- a/spec/report_collector_spec.rb
+++ b/spec/report_collector_spec.rb
@@ -3,14 +3,7 @@ describe Scan do
     let (:path) { "./spec/fixtures/boring.log" }
 
     it "ignores invalid report types" do
-      options = {
-        output_types: "invalid, html",
-        output_directory: "/tmp",
-        project: "examples/standard/app.xcodeproj"
-      }
-      Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
-
-      commands = Scan::ReportCollector.new.generate_commands(path)
+      commands = Scan::ReportCollector.new(false, "invalid, html", "/tmp").generate_commands(path)
 
       expect(commands.count).to eq(1)
       expect(commands).to eq({

--- a/spec/test_command_generator_spec.rb
+++ b/spec/test_command_generator_spec.rb
@@ -1,4 +1,13 @@
 describe Scan do
+  before(:all) do
+    options = { project: "./examples/standard/app.xcodeproj" }
+    config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+    @project = FastlaneCore::Project.new(config)
+  end
+  before(:each) do
+    allow(Scan).to receive(:project).and_return(@project)
+  end
+
   describe Scan::TestCommandGenerator do
     it "raises an exception when project path wasn't found" do
       expect do
@@ -103,7 +112,7 @@ describe Scan do
       it "uses the correct build command with the example project" do
         log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
 
-        options = { project: "./examples/standard/app.xcodeproj", result_bundle: true }
+        options = { project: "./examples/standard/app.xcodeproj", result_bundle: true, scheme: 'app' }
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
         result = Scan::TestCommandGenerator.generate


### PR DESCRIPTION
These changes speed up the `scan` test suite from taking **10.8s** on my laptop, to now only taking **1.57s**.

This applies the same `FastlaneCore::Project` object caching strategy from `gym`'s tests.

The `ReportCollector` is also refactored to extract dependencies on the global `Scan.config` object. This allows this class to be tested in isolation, without needing the expensive `Scan.config =` work.
